### PR TITLE
Add compatibility for module chaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ broadcast/
 # zksync build artifacts
 /artifacts-zk
 /cache-zk
+/zkout
+/cache_hardhat-zk
 
 # zksync local node logs
 era_test_node.log

--- a/src/AgreementEligibility.sol
+++ b/src/AgreementEligibility.sol
@@ -219,14 +219,20 @@ contract AgreementEligibility is HatsEligibilityModule {
     // set bad standing in this contract
     _badStandings[_wearer] = true;
 
-    // revoke _wearer's hat and set their standing to false in Hats.sol
-    HATS().setHatWearerStatus(hatId(), _wearer, false, false);
-
     /**
-     * @dev Hats.sol will emit the following events:
-     *   1. ERC1155.TransferSingle (burn)
-     *   2. Hats.WearerStandingChanged
+     * @dev This logic breaks compatibility with module chains, since the setHatWearerStatus call will revert if this
+     * contract is not directly set as the hat's eligibility module.
+     * TODO post-MVP, bring this back conditional on this contract being directly set as the hat's eligibility
+     * module
      */
+    // revoke _wearer's hat and set their standing to false in Hats.sol
+    // HATS().setHatWearerStatus(hatId(), _wearer, false, false);
+
+    // /**
+    //  * @dev Hats.sol will emit the following events:
+    //  *   1. ERC1155.TransferSingle (burn)
+    //  *   2. Hats.WearerStandingChanged
+    //  */
   }
 
   /**
@@ -237,7 +243,8 @@ contract AgreementEligibility is HatsEligibilityModule {
   function forgive(address _wearer) public onlyArbitrator {
     _badStandings[_wearer] = false;
 
-    HATS().setHatWearerStatus(hatId(), _wearer, true, true);
+    /// @dev Removing this for the same reason as in `revoke()` above
+    // HATS().setHatWearerStatus(hatId(), _wearer, true, true);
 
     /// @dev Hats.sol will emit a Hats.WearerStandingChanged event
   }

--- a/test/AgreementEligibility.t.sol
+++ b/test/AgreementEligibility.t.sol
@@ -364,7 +364,8 @@ contract Forgive is WithInstanceTest {
     instance.forgive(claimer1);
 
     assertTrue(instance.wearerStanding(claimer1));
-    assertFalse(HATS.isWearerOfHat(claimer1, claimableHat));
+    /// @dev This should be true until we bring back the setHatWearerStatus call in `revoke()`
+    assertTrue(HATS.isWearerOfHat(claimer1, claimableHat));
   }
 
   function test_revert_notArbitrator() public {


### PR DESCRIPTION
Removes the call to `Hats.setHatWearerStatus` within the `revoke` and `forgive` functions. This call reverts if the agreement eligibility instance is not set directly as the module on the hat, which breaks compatibility with eligibility module chaining.

TODO
- [ ] update bytecode hash in factory